### PR TITLE
Fixed issue with version check when OS version is greater than 9

### DIFF
--- a/DSCResources/MSFT_xRDRemoteApp/MSFT_xRDRemoteApp.psm1
+++ b/DSCResources/MSFT_xRDRemoteApp/MSFT_xRDRemoteApp.psm1
@@ -1,4 +1,4 @@
-if ([System.Environment]::OSVersion.Version.ToString() -lt "6.2.9200.0") { Throw "The minimum OS requirement was not met."}
+if ([Environment]::OSVersion.Version -lt (new-object 'Version' 6,2,9200,0)) { Throw "The minimum OS requirement was not met."}
 Import-Module RemoteDesktop
 $localhost = [System.Net.Dns]::GetHostByName((hostname)).HostName
 

--- a/DSCResources/MSFT_xRDSessionCollection/MSFT_xRDSessionCollection.psm1
+++ b/DSCResources/MSFT_xRDSessionCollection/MSFT_xRDSessionCollection.psm1
@@ -1,4 +1,4 @@
-if ([System.Environment]::OSVersion.Version.ToString() -lt "6.2.9200.0") { Throw "The minimum OS requirement was not met."}
+if ([Environment]::OSVersion.Version -lt (new-object 'Version' 6,2,9200,0)) { Throw "The minimum OS requirement was not met."}
 Import-Module RemoteDesktop
 $localhost = [System.Net.Dns]::GetHostByName((hostname)).HostName
 

--- a/DSCResources/MSFT_xRDSessionCollectionConfiguration/MSFT_xRDSessionCollectionConfiguration.psm1
+++ b/DSCResources/MSFT_xRDSessionCollectionConfiguration/MSFT_xRDSessionCollectionConfiguration.psm1
@@ -1,4 +1,4 @@
-if ([System.Environment]::OSVersion.Version.ToString() -lt "6.2.9200.0") { Throw "The minimum OS requirement was not met."}
+if ([Environment]::OSVersion.Version -lt (new-object 'Version' 6,2,9200,0)) { Throw "The minimum OS requirement was not met."}
 Import-Module RemoteDesktop
 $localhost = [System.Net.Dns]::GetHostByName((hostname)).HostName
 

--- a/DSCResources/MSFT_xRDSessionDeployment/MSFT_xRDSessionDeployment.psm1
+++ b/DSCResources/MSFT_xRDSessionDeployment/MSFT_xRDSessionDeployment.psm1
@@ -1,4 +1,4 @@
-if ([System.Environment]::OSVersion.Version.ToString() -lt "6.2.9200.0") { Throw "The minimum OS requirement was not met."}
+if ([Environment]::OSVersion.Version -lt (new-object 'Version' 6,2,9200,0)) { Throw "The minimum OS requirement was not met."}
 Import-Module RemoteDesktop
 
 #######################################################################


### PR DESCRIPTION
OS check would fail with any version greater than 9 (Windows 10/2016)