### PR TITLE
Fix loading DSC Resource helper function psm1 file

### DIFF
--- a/DSCResources/MSFT_xRDRemoteApp/MSFT_xRDRemoteApp.psm1
+++ b/DSCResources/MSFT_xRDRemoteApp/MSFT_xRDRemoteApp.psm1
@@ -1,3 +1,4 @@
+Import-Module -Name "$PSScriptRoot\..\..\xRemoteDesktopSessionHostCommon.psm1"
 if (!(Test-xRemoteDesktopSessionHostOsRequirement)) { Throw "The minimum OS requirement was not met."}
 Import-Module RemoteDesktop
 $localhost = [System.Net.Dns]::GetHostByName((hostname)).HostName

--- a/DSCResources/MSFT_xRDSessionCollection/MSFT_xRDSessionCollection.psm1
+++ b/DSCResources/MSFT_xRDSessionCollection/MSFT_xRDSessionCollection.psm1
@@ -1,3 +1,4 @@
+Import-Module -Name "$PSScriptRoot\..\..\xRemoteDesktopSessionHostCommon.psm1"
 if (!(Test-xRemoteDesktopSessionHostOsRequirement)) { Throw "The minimum OS requirement was not met."}
 Import-Module RemoteDesktop
 $localhost = [System.Net.Dns]::GetHostByName((hostname)).HostName

--- a/DSCResources/MSFT_xRDSessionCollectionConfiguration/MSFT_xRDSessionCollectionConfiguration.psm1
+++ b/DSCResources/MSFT_xRDSessionCollectionConfiguration/MSFT_xRDSessionCollectionConfiguration.psm1
@@ -1,3 +1,4 @@
+Import-Module -Name "$PSScriptRoot\..\..\xRemoteDesktopSessionHostCommon.psm1"
 if (!(Test-xRemoteDesktopSessionHostOsRequirement)) { Throw "The minimum OS requirement was not met."}
 Import-Module RemoteDesktop
 $localhost = [System.Net.Dns]::GetHostByName((hostname)).HostName

--- a/DSCResources/MSFT_xRDSessionDeployment/MSFT_xRDSessionDeployment.psm1
+++ b/DSCResources/MSFT_xRDSessionDeployment/MSFT_xRDSessionDeployment.psm1
@@ -1,3 +1,4 @@
+Import-Module -Name "$PSScriptRoot\..\..\xRemoteDesktopSessionHostCommon.psm1"
 if (!(Test-xRemoteDesktopSessionHostOsRequirement)) { Throw "The minimum OS requirement was not met."}
 Import-Module RemoteDesktop
 


### PR DESCRIPTION
This fixes an issue where the helper function psm1 file is not loaded  properly when the DSC Resource is not located in one of the default PS paths. This issue was found in https://tickets.puppetlabs.com/browse/MODULES-3686.