### PR TITLE
Update MSFT_xRDRemoteApp.schema.mof

### DIFF
--- a/DSCResources/MSFT_xRDRemoteApp/MSFT_xRDRemoteApp.schema.mof
+++ b/DSCResources/MSFT_xRDRemoteApp/MSFT_xRDRemoteApp.schema.mof
@@ -12,7 +12,7 @@ class MSFT_xRDRemoteApp : OMI_BaseResource
     [write, Description("Specifies a string that contains command-line arguments that the client can use at connection time with the RemoteApp program. ")] string RequiredCommandLine;
     [write, Description("Specifies the index within the icon file (specified by the IconPath parameter) where the RemoteApp program's icon can be found.")] uint32 IconIndex;
     [write, Description("Specifies the path to a file containing the icon to display for the RemoteApp program identified by the Alias parameter.")] string IconPath;
-    [write, Description("Specifies a domain group that can view the RemoteApp in RD Web Access, and in RemoteApp and Desktop Connections. To allow all users to see a RemoteApp program, provide a value of Null.")] string UserGroups;
+    [write, Description("Specifies a domain group that can view the RemoteApp in RD Web Access, and in RemoteApp and Desktop Connections. To allow all users to see a RemoteApp program, provide a value of Null.")] string UserGroups[];
     [write, Description("Specifies whether to show the RemoteApp program in the RD Web Access server, and in RemoteApp and Desktop Connections that the user subscribes to. ")] boolean ShowInWebAccess;
 };
 


### PR DESCRIPTION
UserGroups should be set as a string table. Otherwise there will be not possible to define more than one user or group to be added to particular remote app. This update solves following issue:

https://gallery.technet.microsoft.com/scriptcenter/xRemoteDesktopSessionHost-4a11f27d/view/Discussions#content

Post described as "Problem with attribute UserGroups in xRDRemoteApp".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xremotedesktopsessionhost/18)
<!-- Reviewable:end -->
