### PR TITLE
Update MSFT_xRDRemoteApp.psm1

### DIFF
--- a/DSCResources/MSFT_xRDRemoteApp/MSFT_xRDRemoteApp.psm1
+++ b/DSCResources/MSFT_xRDRemoteApp/MSFT_xRDRemoteApp.psm1
@@ -27,7 +27,7 @@ function Get-TargetResource
         [string] $RequiredCommandLine,
         [uint32] $IconIndex,
         [string] $IconPath,
-        [string] $UserGroups,
+        [string[]] $UserGroups,
         [boolean] $ShowInWebAccess
     )
         Write-Verbose "Getting published RemoteApp program $DisplayName, if one exists."
@@ -75,7 +75,7 @@ function Set-TargetResource
         [string] $RequiredCommandLine,
         [uint32] $IconIndex,
         [string] $IconPath,
-        [string] $UserGroups,
+        [string[]] $UserGroups,
         [boolean] $ShowInWebAccess
     )
     Write-Verbose "Making updates to RemoteApp."
@@ -114,7 +114,7 @@ function Test-TargetResource
         [string] $RequiredCommandLine,
         [uint32] $IconIndex,
         [string] $IconPath,
-        [string] $UserGroups,
+        [string[]] $UserGroups,
         [boolean] $ShowInWebAccess
     )
     Write-Verbose "Testing if RemoteApp is published."


### PR DESCRIPTION
$UserGroups should be set as a string table (the same modification needs to be done in MSFT_xRDRemoteApp.schema.mof). Otherwise there will be not possible to define more than one user or group to be added to particular remote app. This update solves following issue:

https://gallery.technet.microsoft.com/scriptcenter/xRemoteDesktopSessionHost-4a11f27d/view/Discussions#content

Post described as "Problem with attribute UserGroups in xRDRemoteApp".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xremotedesktopsessionhost/19)
<!-- Reviewable:end -->
