### PR TITLE
Fix issue where DSC configuration gets into a reboot loop because ses…

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 
 ### Unreleased
 
+* Fix issue where DSC configuration gets into a reboot loop because sessionhost does not match (casing) and RDMS service is not started in time
+
 ### 1.4.0.0
 
 * Updated CollectionName parameter to validate length between 1 and 15 characters, and added tests to verify.


### PR DESCRIPTION
Fix issue where DSC configuration gets into a reboot loop because sessionhost does not match (casing) and RDMS service is not started in time

original issue/fix: https://gallery.technet.microsoft.com/scriptcenter/xRemoteDesktopSessionHost-4a11f27d/view/Discussions

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xremotedesktopsessionhost/24)
<!-- Reviewable:end -->
