### PR TITLE
Incorrect Parameter name fixed

### DIFF
--- a/DSCResources/MSFT_xRDSessionCollection/MSFT_xRDSessionCollection.psm1
+++ b/DSCResources/MSFT_xRDSessionCollection/MSFT_xRDSessionCollection.psm1
@@ -53,7 +53,7 @@ function Set-TargetResource
         New-RDSessionCollection @PSBoundParameters
         }
     else {
-        $PSBoundParameters.Remove("Description")
+        $PSBoundParameters.Remove("CollectionDescription")
         Add-RDSessionHost @PSBoundParameters
         }
 }


### PR DESCRIPTION
When applying *xRDSessionCollection* to an RDS Host which is not also a Connection Broker the following error is being thrown:

`
A parameter cannot be found that matches parameter name 'CollectionDescription'.
    + CategoryInfo          : InvalidArgument: (:) [], CimException
    + FullyQualifiedErrorId : NamedParameterNotFound,Add-RDSessionHost
    + PSComputerName        : localhost
`