### PR TITLE
Fix false positive when another Collection exists

### DIFF
--- a/DSCResources/MSFT_xRDSessionCollection/MSFT_xRDSessionCollection.psm1
+++ b/DSCResources/MSFT_xRDSessionCollection/MSFT_xRDSessionCollection.psm1
@@ -21,7 +21,7 @@ function Get-TargetResource
         [string] $ConnectionBroker
     )
     Write-Verbose "Getting information about RDSH collection."
-        $Collection = Get-RDSessionCollection -ErrorAction SilentlyContinue
+        $Collection = Get-RDSessionCollection -CollectionName $CollectionName -ConnectionBroker $ConnectionBroker -ErrorAction SilentlyContinue
         @{
         "CollectionName" = $Collection.CollectionName;
         "CollectionDescription" = $Collection.CollectionDescription


### PR DESCRIPTION
The Test was passing when a Collection with a different name was present.

Added CollectionName and ConnectionBroker to Get-TargetResource (which is referenced by Test-TargetResource) to prevent the test from passing when a  Collection with a different name exists.