### PR TITLE
xRDSessionDeployment and xRDRemoteApp: Adding tests and fixes for #39, #41

### DIFF
--- a/DSCResources/MSFT_xRDRemoteApp/MSFT_xRDRemoteApp.psm1
+++ b/DSCResources/MSFT_xRDRemoteApp/MSFT_xRDRemoteApp.psm1
@@ -42,43 +42,44 @@ function Get-TargetResource
         [Parameter()]
         [boolean] $ShowInWebAccess
     )
-        Write-Verbose "Getting published RemoteApp program $DisplayName, if one exists."
-        try 
-        {
-            $null = Get-RDSessionCollection -CollectionName $CollectionName -ErrorAction Stop
-        }
-        catch 
-        {
-            throw "Failed to lookup RD Session Collection $CollectionName. Error: $_"
-        }
 
-        $remoteApp = Get-RDRemoteApp -CollectionName $CollectionName -Alias $Alias -ErrorAction SilentlyContinue
+    try
+    {
+        $null = Get-RDSessionCollection -CollectionName $CollectionName -ErrorAction Stop
+    }
+    catch
+    {
+        throw "Failed to lookup RD Session Collection $CollectionName. Error: $_"
+    }
 
-        $return = @{
-            CollectionName = $remoteApp.CollectionName
-            DisplayName = $remoteApp.DisplayName
-            FilePath = $remoteApp.FilePath
-            Alias = $remoteApp.Alias
-            FileVirtualPath = $remoteApp.FileVirtualPath
-            FolderName = $remoteApp.FolderName
-            CommandLineSetting = $remoteApp.CommandLineSetting
-            RequiredCommandLine = $remoteApp.RequiredCommandLine
-            IconIndex = $remoteApp.IconIndex
-            IconPath = $remoteApp.IconPath
-            UserGroups = $remoteApp.UserGroups
-            ShowInWebAccess = $remoteApp.ShowInWebAccess
-        }
+    Write-Verbose "Getting published RemoteApp program $DisplayName, if one exists."
+    $remoteApp = Get-RDRemoteApp -CollectionName $CollectionName -Alias $Alias -ErrorAction SilentlyContinue
 
-        if($remoteApp) 
-        {
-            $return['Ensure'] = 'Present'
-        }
-        else
-        {
-            $return['Ensure'] = 'Absent'
-        }
+    $return = @{
+        CollectionName = $remoteApp.CollectionName
+        DisplayName = $remoteApp.DisplayName
+        FilePath = $remoteApp.FilePath
+        Alias = $remoteApp.Alias
+        FileVirtualPath = $remoteApp.FileVirtualPath
+        FolderName = $remoteApp.FolderName
+        CommandLineSetting = $remoteApp.CommandLineSetting
+        RequiredCommandLine = $remoteApp.RequiredCommandLine
+        IconIndex = $remoteApp.IconIndex
+        IconPath = $remoteApp.IconPath
+        UserGroups = $remoteApp.UserGroups
+        ShowInWebAccess = $remoteApp.ShowInWebAccess
+    }
 
-        $return
+    if($remoteApp)
+    {
+        $return['Ensure'] = 'Present'
+    }
+    else
+    {
+        $return['Ensure'] = 'Absent'
+    }
+
+    $return
 }
 
 
@@ -121,9 +122,8 @@ function Set-TargetResource
         [Parameter()]
         [boolean] $ShowInWebAccess
     )
-    Write-Verbose "Making updates to RemoteApp."
-    
-    try 
+
+    try
     {
         $null = Get-RDSessionCollection -CollectionName $CollectionName -ErrorAction Stop
         $null = $PSBoundParameters.Remove('Ensure')
@@ -133,8 +133,9 @@ function Set-TargetResource
         throw "Failed to lookup RD Session Collection $CollectionName. Error: $_"
     }
 
+    Write-Verbose "Making updates to RemoteApp."
     $remoteApp = Get-RDRemoteApp -CollectionName $CollectionName -Alias $Alias
-    if (!$remoteApp -and $Ensure -eq 'Present') 
+    if (!$remoteApp -and $Ensure -eq 'Present')
     {
         New-RDRemoteApp @PSBoundParameters
     }
@@ -142,7 +143,7 @@ function Set-TargetResource
     {
         Remove-RDRemoteApp -CollectionName $CollectionName -Alias $Alias -Force
     }
-    else 
+    else
     {
         Set-RDRemoteApp @PSBoundParameters
     }
@@ -200,21 +201,18 @@ function Test-TargetResource
         throw "Failed to lookup RD Session Collection $CollectionName. Error: $_"
     }
 
-    $null = $PSBoundParameters.Remove("Verbose")
-    $null = $PSBoundParameters.Remove("Debug")
-    $null = $PSBoundParameters.Remove("ConnectionBroker")
-    $check = $true
+    $testTargetResourceResult = $true
     
-    $get = Get-TargetResource @PSBoundParameters
-    $PSBoundParameters.keys | ForEach-Object {
-        if ($PSBoundParameters[$_] -ne $get[$_]) 
+    $getTargetResourceResult = Get-TargetResource @PSBoundParameters
+    $PSBoundParameters.Keys | ForEach-Object -Process {
+        if ($PSBoundParameters[$_] -ne $getTargetResourceResult[$_]) 
         {
-            Write-Verbose "Property [ $_ ] with value $($PSBoundParameters[$_]) does not match $($get[$_])"
-            $check = $false
+            Write-Verbose "Property [ $_ ] with value $($PSBoundParameters[$_]) does not match $($getTargetResourceResult[$_])"
+            $testTargetResourceResult = $false
         }
     }
 
-    $check
+    $testTargetResourceResult
 }
 
 Export-ModuleMember -Function *-TargetResource

--- a/DSCResources/MSFT_xRDRemoteApp/MSFT_xRDRemoteApp.psm1
+++ b/DSCResources/MSFT_xRDRemoteApp/MSFT_xRDRemoteApp.psm1
@@ -1,7 +1,7 @@
 Import-Module -Name "$PSScriptRoot\..\..\xRemoteDesktopSessionHostCommon.psm1"
 if (!(Test-xRemoteDesktopSessionHostOsRequirement)) { Throw "The minimum OS requirement was not met."}
 Import-Module RemoteDesktop
-$localhost = [System.Net.Dns]::GetHostByName((hostname)).HostName
+
 
 #######################################################################
 # The Get-TargetResource cmdlet.
@@ -14,18 +14,22 @@ function Get-TargetResource
     (
         [Parameter(Mandatory = $true)]
         [ValidateLength(1,15)]
-        [string] $CollectionName, #eg Tenant
+        [string] $CollectionName,
         [Parameter(Mandatory = $true)]
-        [string] $DisplayName, #eg Calculator
+        [string] $DisplayName,
         [Parameter(Mandatory = $true)]
-        [string] $FilePath, #eg C:\Windows\System32\calc.exe
+        [string] $FilePath,
         [Parameter(Mandatory = $true)]
-        [string] $Alias, #eg calc
+        [string] $Alias,
+        [Parameter()]
+        [ValidateSet('Present','Absent')]
+        [string]$Ensure = 'Present',
         [Parameter()]
         [string] $FileVirtualPath,
         [Parameter()]
         [string] $FolderName,
         [Parameter()]
+        [ValidateSet('Allow','DoNotAllow','Require')]
         [string] $CommandLineSetting,
         [Parameter()]
         [string] $RequiredCommandLine,
@@ -39,23 +43,42 @@ function Get-TargetResource
         [boolean] $ShowInWebAccess
     )
         Write-Verbose "Getting published RemoteApp program $DisplayName, if one exists."
-        $CollectionName = Get-RDSessionCollection | ForEach-Object {Get-RDSessionHost $_.CollectionName} | Where-Object {$_.SessionHost -ieq $localhost} | ForEach-Object {$_.CollectionName}
-        $remoteApp = Get-RDRemoteApp -CollectionName $CollectionName -DisplayName $DisplayName -Alias $Alias
-
-        @{
-        "CollectionName" = $remoteApp.CollectionName;
-        "DisplayName" = $remoteApp.DisplayName;
-        "FilePath" = $remoteApp.FilePath;
-        "Alias" = $remoteApp.Alias;
-        "FileVirtualPath" = $remoteApp.FileVirtualPath;
-        "FolderName" = $remoteApp.FolderName;
-        "CommandLineSetting" = $remoteApp.CommandLineSetting;
-        "RequiredCommandLine" = $remoteApp.RequiredCommandLine;
-        "IconIndex" = $remoteApp.IconIndex;
-        "IconPath" = $remoteApp.IconPath;
-        "UserGroups" = $remoteApp.UserGroups;
-        "ShowInWebAccess" = $remoteApp.ShowInWebAccess;
+        try 
+        {
+            $null = Get-RDSessionCollection -CollectionName $CollectionName -ErrorAction Stop
         }
+        catch 
+        {
+            throw "Failed to lookup RD Session Collection $CollectionName. Error: $_"
+        }
+
+        $remoteApp = Get-RDRemoteApp -CollectionName $CollectionName -Alias $Alias -ErrorAction SilentlyContinue
+
+        $return = @{
+            CollectionName = $remoteApp.CollectionName
+            DisplayName = $remoteApp.DisplayName
+            FilePath = $remoteApp.FilePath
+            Alias = $remoteApp.Alias
+            FileVirtualPath = $remoteApp.FileVirtualPath
+            FolderName = $remoteApp.FolderName
+            CommandLineSetting = $remoteApp.CommandLineSetting
+            RequiredCommandLine = $remoteApp.RequiredCommandLine
+            IconIndex = $remoteApp.IconIndex
+            IconPath = $remoteApp.IconPath
+            UserGroups = $remoteApp.UserGroups
+            ShowInWebAccess = $remoteApp.ShowInWebAccess
+        }
+
+        if($remoteApp) 
+        {
+            $return['Ensure'] = 'Present'
+        }
+        else
+        {
+            $return['Ensure'] = 'Absent'
+        }
+
+        $return
 }
 
 
@@ -78,10 +101,14 @@ function Set-TargetResource
         [Parameter(Mandatory = $true)]
         [string] $Alias,
         [Parameter()]
+        [ValidateSet('Present','Absent')]
+        [string]$Ensure = 'Present',
+        [Parameter()]
         [string] $FileVirtualPath,
         [Parameter()]
         [string] $FolderName,
         [Parameter()]
+        [ValidateSet('Allow','DoNotAllow','Require')]
         [string] $CommandLineSetting,
         [Parameter()]
         [string] $RequiredCommandLine,
@@ -95,11 +122,25 @@ function Set-TargetResource
         [boolean] $ShowInWebAccess
     )
     Write-Verbose "Making updates to RemoteApp."
-    $CollectionName = Get-RDSessionCollection | ForEach-Object {Get-RDSessionHost $_.CollectionName} | Where-Object {$_.SessionHost -ieq $localhost} | ForEach-Object {$_.CollectionName}
-    $PSBoundParameters.collectionName = $CollectionName
-    if (!$(Get-RDRemoteApp -Alias $Alias)) 
+    
+    try 
+    {
+        $null = Get-RDSessionCollection -CollectionName $CollectionName -ErrorAction Stop
+        $null = $PSBoundParameters.Remove('Ensure')
+    }
+    catch 
+    {
+        throw "Failed to lookup RD Session Collection $CollectionName. Error: $_"
+    }
+
+    $remoteApp = Get-RDRemoteApp -CollectionName $CollectionName -Alias $Alias
+    if (!$remoteApp -and $Ensure -eq 'Present') 
     {
         New-RDRemoteApp @PSBoundParameters
+    }
+    elseif ($remoteApp -and $Ensure -eq 'Absent')
+    {
+        Remove-RDRemoteApp -CollectionName $CollectionName -Alias $Alias -Force
     }
     else 
     {
@@ -127,10 +168,14 @@ function Test-TargetResource
         [Parameter(Mandatory = $true)]
         [string] $Alias,
         [Parameter()]
+        [ValidateSet('Present','Absent')]
+        [string]$Ensure = 'Present',
+        [Parameter()]
         [string] $FileVirtualPath,
         [Parameter()]
         [string] $FolderName,
         [Parameter()]
+        [ValidateSet('Allow','DoNotAllow','Require')]
         [string] $CommandLineSetting,
         [Parameter()]
         [string] $RequiredCommandLine,
@@ -143,16 +188,33 @@ function Test-TargetResource
         [Parameter()]
         [boolean] $ShowInWebAccess
     )
+
     Write-Verbose "Testing if RemoteApp is published."
-    $collectionName = Get-RDSessionCollection | ForEach-Object {Get-RDSessionHost $_.CollectionName} | Where-Object {$_.SessionHost -ieq $localhost} | ForEach-Object {$_.CollectionName}
-    $PSBoundParameters.Remove("Verbose") | out-null
-    $PSBoundParameters.Remove("Debug") | out-null
-    $PSBoundParameters.Remove("ConnectionBroker") | out-null
-    $Check = $true
+
+    try 
+    {
+        $null = Get-RDSessionCollection -CollectionName $CollectionName -ErrorAction Stop
+    }
+    catch
+    {
+        throw "Failed to lookup RD Session Collection $CollectionName. Error: $_"
+    }
+
+    $null = $PSBoundParameters.Remove("Verbose")
+    $null = $PSBoundParameters.Remove("Debug")
+    $null = $PSBoundParameters.Remove("ConnectionBroker")
+    $check = $true
     
-    $Get = Get-TargetResource -CollectionName $CollectionName -DisplayName $DisplayName -FilePath $FilePath -Alias $Alias
-    $PSBoundParameters.keys | ForEach-Object {if ($PSBoundParameters[$_] -ne $Get[$_]) {$Check = $false} }
-    $Check
+    $get = Get-TargetResource @PSBoundParameters
+    $PSBoundParameters.keys | ForEach-Object {
+        if ($PSBoundParameters[$_] -ne $get[$_]) 
+        {
+            Write-Verbose "Property [ $_ ] with value $($PSBoundParameters[$_]) does not match $($get[$_])"
+            $check = $false
+        }
+    }
+
+    $check
 }
 
 Export-ModuleMember -Function *-TargetResource

--- a/DSCResources/MSFT_xRDRemoteApp/MSFT_xRDRemoteApp.schema.mof
+++ b/DSCResources/MSFT_xRDRemoteApp/MSFT_xRDRemoteApp.schema.mof
@@ -4,16 +4,15 @@ class MSFT_xRDRemoteApp : OMI_BaseResource
 {
     [key, Description("Specifies an alias for the RemoteApp program.")] string Alias;
     [key, Description("Specifies the name of the personal virtual desktop collection or session collection. The cmdlet publishes the RemoteApp program to this collection. ")] string CollectionName;
-    [key, Description("Specifies a name to display to users for the RemoteApp program.")] string DisplayName;
-    [key, Description("Specifies a path for the executable file for the application. Do not include any environment variables.")] string FilePath;
+    [required, Description("Specifies a name to display to users for the RemoteApp program.")] string DisplayName;
+    [required, Description("Specifies a path for the executable file for the application. Do not include any environment variables.")] string FilePath;
+    [Write, Description("Present if the RemoteApp should exist, Absent if it should be removed"), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] string Ensure;
     [write, Description("Specifies a path for the application executable file. This path resolves to the same location as the value of the FilePath parameter, but it can include environment variables. ")] string FileVirtualPath;
     [write, Description("Specifies the name of the folder that the RemoteApp program appears in on the Remote Desktop Web Access (RD Web Access) webpage and in the Start menu for subscribed RemoteApp and Desktop Connections. ")] string FolderName;
-    [write, Description("Specifies whether the RemoteApp program accepts command-line arguments from the client at connection time. The acceptable values for this parameter are:  Allow, DoNotAllow, Require")] string CommandLineSetting;
+    [write, Description("Specifies whether the RemoteApp program accepts command-line arguments from the client at connection time. The acceptable values for this parameter are:  Allow, DoNotAllow, Require"), ValueMap{"Allow", "DoNotAllow", "Require"}, Values{"Allow", "DoNotAllow", "Require"}] string CommandLineSetting;
     [write, Description("Specifies a string that contains command-line arguments that the client can use at connection time with the RemoteApp program. ")] string RequiredCommandLine;
     [write, Description("Specifies the index within the icon file (specified by the IconPath parameter) where the RemoteApp program's icon can be found.")] uint32 IconIndex;
     [write, Description("Specifies the path to a file containing the icon to display for the RemoteApp program identified by the Alias parameter.")] string IconPath;
     [write, Description("Specifies a domain group that can view the RemoteApp in RD Web Access, and in RemoteApp and Desktop Connections. To allow all users to see a RemoteApp program, provide a value of Null.")] string UserGroups;
     [write, Description("Specifies whether to show the RemoteApp program in the RD Web Access server, and in RemoteApp and Desktop Connections that the user subscribes to. ")] boolean ShowInWebAccess;
 };
-
-

--- a/README.md
+++ b/README.md
@@ -84,11 +84,12 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 
 * **Alias**: Specifies an alias for the RemoteApp program.
 * **CollectionName**: Specifies the name of the personal virtual desktop collection or session collection.  The cmdlet publishes the RemoteApp program to this collection.
+* **Ensure**: Specifies if the RemoteApp needs to be Present (default) or Absent.
 * **DisplayName**: Specifies a name to display to users for the RemoteApp program.
 * **FilePath**: Specifies a path for the executable file for the application.  Note: Do not include any environment variables.
 * **FileVirtualPath**: Specifies a path for the application executable file.  This path resolves to the same location as the value of the FilePath parameter, but it can include environment variables.
 * **FolderName**: Specifies the name of the folder that the RemoteApp program appears in on the Remote Desktop Web Access (RD Web Access) webpage and in the Start menu for subscribed RemoteApp and Desktop Connections.
-* **CommandLineSetting**: Specifies whether the RemoteApp program accepts command-line arguments from the client at connection time.
+* **CommandLineSetting**: Specifies whether the RemoteApp program accepts command-line arguments from the client at connection time. Parameters accepts Allow, DoNotAllow or Require as values.
 * **RequiredCommandLine**: Specifies a string that contains command-line arguments that the client can use at connection time with the RemoteApp program.
 * **IconIndex**: Specifies the index within the icon file (specified by the IconPath parameter) where the RemoteApp program's icon can be found.
 * **IconPath**: Specifies the path to a file containing the icon to display for the RemoteApp program identified by the Alias parameter.

--- a/README.md
+++ b/README.md
@@ -129,6 +129,14 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
   * Fixed call to Add-RDSessionHost in Set-TargetResource by properly removing CollectionDescription from PSBoundParameters (issue #28)
   * Fixed bug on Get-TargetResource that did return any collection instead of the one collection the user asked for (issue #27)
   * Added unit tests to test Get, Test and Set results in this resource
+* xRDSessionDeployment:
+  * Fixed issue where an initial deployment failed due to a convert to lowercase (issue #39)
+  * Added unit tests to test Get, Test and Set results in this resource
+* xRDRemoteApp:
+  * Fixed issue where this resource ignored the CollectionName provided in the parameters (issue #41)
+  * Changed key values in schema.mof to only Alias and CollectionName, DisplayName and FilePath are not key values
+  * Added Ensure property (Absent or Present) to enable removal of RemoteApps
+  * Added unit tests to test Get, Test and Set results in this resource
 
 ### 1.6.0.0
 

--- a/tests/unit/MSFT_xRDRemoteApp.tests.ps1
+++ b/tests/unit/MSFT_xRDRemoteApp.tests.ps1
@@ -76,19 +76,19 @@ try
                 }
 
                 $xRDRemoteAppSplat.CommandLineSetting = 'Invalid'
-                It 'Does only accept valid values for CommandLineSetting' {
+                It 'Should only accept valid values for CommandLineSetting' {
                     { Get-TargetResource @xRDRemoteAppSplat } | Should Throw
                 }
 
                 $xRDRemoteAppSplat.CommandLineSetting = 'DoNotAllow'
             }
 
-            Context "Get output validation" {
+            Context "When Get-TargetResource is called" {
                 
                 Mock -CommandName Get-RDRemoteApp
                 Mock -CommandName Get-RDSessionCollection
 
-                It 'Given the RemoteApp is not created yet, get returns Absent' {
+                It 'Should return Ensure Absent, given the RemoteApp is not created yet' {
                     (Get-TargetResource @xRDRemoteAppSplat).Ensure | Should Be 'Absent'
                 }
 
@@ -109,7 +109,7 @@ try
                     }
                 }
 
-                It 'Given the RemoteApp is created, get returns Present' {
+                It 'Should return Ensure Present, given the RemoteApp is created' {
                     (Get-TargetResource @xRDRemoteAppSplat).Ensure | Should Be 'Present'
                 }
 
@@ -127,28 +127,28 @@ try
                     'PipelineVariable'
                 )
 
-                $allParameters = (Get-Command Get-TargetResource).Parameters.Keys | Where-Object{$_ -notin $excludeParameters} | ForEach-Object {
+                $allParameters = (Get-Command Get-TargetResource).Parameters.Keys | Where-Object { $_ -notin $excludeParameters } | ForEach-Object -Process {
                     @{
                         Property = $_
                         Value = $xRDRemoteAppSplat[$_]
                     }
                 }
 
-                $get = Get-TargetResource @xRDRemoteAppSplat
-                It 'Get returns property <Property> with value <Value>' {
+                $getTargetResourceResult = Get-TargetResource @xRDRemoteAppSplat
+                It 'Should return property <Property> with value <Value> in Get-TargetResource' {
                     Param(
                         $Property,
                         $Value
                     )
 
-                    $get.$Property | Should Be $Value
+                    $getTargetResourceResult.$Property | Should Be $Value
                 } -TestCases $allParameters
 
                 Mock -CommandName Get-RDSessionCollection -MockWith {
                     Write-Error 'Collection not found!'
                 }
 
-                It 'Given that the CollectionName is not found in the SessionDeployment, an error is generated' {
+                It 'Should generate an error, given that the CollectionName is not found in the SessionDeployment' {
                     try
                     {
                         Get-TargetResource @xRDRemoteAppSplat -ErrorVariable collectionError
@@ -171,14 +171,14 @@ try
                 }
 
                 $xRDRemoteAppSplat.CommandLineSetting = 'Invalid'
-                It 'Does only accept valid values for CommandLineSetting' {
+                It 'Should only accept valid values for CommandLineSetting' {
                     { Get-TargetResource @xRDRemoteAppSplat } | Should Throw
                 }
 
                 $xRDRemoteAppSplat.CommandLineSetting = 'DoNotAllow'
             }
 
-            Context 'Validate Set Actions' {
+            Context 'When Set-TargetResource actions are performed' {
 
                 Mock -CommandName Get-RDSessionCollection
                 Mock -CommandName Get-RDRemoteApp
@@ -186,20 +186,20 @@ try
                 Mock -CommandName Remove-RDRemoteApp
                 Mock -CommandName Set-RDRemoteApp
 
-                It 'Given that the RemoteApp does not exist yet and Ensure is set to Present, New-RDRemoteApp is called' {
+                It 'Should call New-RDRemoteApp, given that the RemoteApp does not exist yet and Ensure is set to Present' {
                     Set-TargetResource @xRDRemoteAppSplat
                     Assert-MockCalled -CommandName New-RDRemoteApp -Times 1 -Scope It
                 }
 
                 Mock -CommandName Get-RDRemoteApp -MockWith { $true }
 
-                It 'Given that the RemoteApp does exist and Ensure is set to Present, Set-RDRemoteApp is called' {
+                It 'Should call Set-RDRemoteApp, given that the RemoteApp does exist and Ensure is set to Present' {
                     Set-TargetResource @xRDRemoteAppSplat
                     Assert-MockCalled -CommandName Set-RDRemoteApp -Times 1 -Scope It
                 }
 
                 $xRDRemoteAppSplat.Ensure = 'Absent'
-                It 'Given that the RemoteApp exists and Ensure is set to Absent, Remove-RDRemoteApp is called' {
+                It 'Should call Remove-RDRemoteApp, given that the RemoteApp exists and Ensure is set to Absent' {
                     Set-TargetResource @xRDRemoteAppSplat
                     Assert-MockCalled -CommandName Remove-RDRemoteApp -Times 1 -Scope It
                 }
@@ -209,7 +209,7 @@ try
                     Write-Error 'Collection not found!'
                 }
 
-                It 'Given that the CollectionName is not found in the SessionDeployment, an error is generated' {
+                It 'Should generate an error, given that the CollectionName is not found in the SessionDeployment' {
                     try
                     {
                         Set-TargetResource @xRDRemoteAppSplat -ErrorVariable collectionError
@@ -232,7 +232,7 @@ try
                 }
                 
                 $xRDRemoteAppSplat.CommandLineSetting = 'Invalid'
-                It 'Does only accept valid values for CommandLineSetting' {
+                It 'Should only accept valid values for CommandLineSetting' {
                     { Get-TargetResource @xRDRemoteAppSplat } | Should Throw
                 }
 
@@ -243,11 +243,11 @@ try
                 Mock -CommandName Get-RDSessionCollection
                 Mock -CommandName Get-RDRemoteApp
 
-                It 'Given that the RemoteApp does not exist yet and Ensure is set to Present, test returns false' {
+                It 'Should return false, given that the RemoteApp does not exist yet and Ensure is set to Present' {
                     Test-TargetResource @xRDRemoteAppSplat | Should Be $false
                 }
 
-                Mock -CommandName Get-RDRemoteApp -MockWith { 
+                Mock -CommandName Get-RDRemoteApp -MockWith {
                     @{
                         CollectionName = 'TestCollection'
                         DisplayName = 'MyCalc (1.0.0)'
@@ -264,17 +264,17 @@ try
                     }
                 }
 
-                It 'Given that the RemoteApp does exist and Ensure is set to Present, test returns true' {
+                It 'Should return true, given that the RemoteApp does exist and Ensure is set to Present' {
                     Test-TargetResource @xRDRemoteAppSplat | Should Be $true
                 }
 
                 $xRDRemoteAppSplat.Ensure = 'Absent'
-                It 'Given that the RemoteApp exists and Ensure is set to Absent, test returns false' {
+                It 'Should return false, given that the RemoteApp exists and Ensure is set to Absent' {
                     Test-TargetResource @xRDRemoteAppSplat | Should Be $false
                 }
                 $xRDRemoteAppSplat.Ensure = 'Present'
 
-                Mock -CommandName Get-RDRemoteApp -MockWith { 
+                Mock -CommandName Get-RDRemoteApp -MockWith {
                     @{
                         CollectionName = 'TestCollection'
                         DisplayName = 'MyCalc (1.0.0)'
@@ -291,7 +291,7 @@ try
                     }
                 }
 
-                It 'Given that the RemoteApp exists and Ensure is set to Present and a single setting is misconfigured, test returns false' {
+                It 'Should return false, given that the RemoteApp exists and Ensure is set to Present and a single setting is misconfigured' {
                     Test-TargetResource @xRDRemoteAppSplat | Should Be $false
                 }
 
@@ -299,7 +299,7 @@ try
                     Write-Error 'Collection not found!'
                 }
 
-                It 'Given that the CollectionName is not found in the SessionDeployment, an error is generated' {
+                It 'Should generate an error, given that the CollectionName is not found in the SessionDeployment' {
                     try
                     {
                         Test-TargetResource @xRDRemoteAppSplat -ErrorVariable collectionError

--- a/tests/unit/MSFT_xRDRemoteApp.tests.ps1
+++ b/tests/unit/MSFT_xRDRemoteApp.tests.ps1
@@ -127,12 +127,14 @@ try
                     'PipelineVariable'
                 )
 
-                $allParameters = (Get-Command Get-TargetResource).Parameters.Keys | Where-Object { $_ -notin $excludeParameters } | ForEach-Object -Process {
-                    @{
-                        Property = $_
-                        Value = $xRDRemoteAppSplat[$_]
+                $allParameters = (Get-Command Get-TargetResource).Parameters.Keys |
+                    Where-Object -FilterScript { $_ -notin $excludeParameters } |
+                    ForEach-Object -Process {
+                        @{
+                            Property = $_
+                            Value = $xRDRemoteAppSplat[$_]
+                        }
                     }
-                }
 
                 $getTargetResourceResult = Get-TargetResource @xRDRemoteAppSplat
                 It 'Should return property <Property> with value <Value> in Get-TargetResource' {

--- a/tests/unit/MSFT_xRDRemoteApp.tests.ps1
+++ b/tests/unit/MSFT_xRDRemoteApp.tests.ps1
@@ -7,7 +7,7 @@ $script:DSCResourceName    = 'MSFT_xRDRemoteApp'
 $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 Write-Output @('clone','https://github.com/PowerShell/DscResource.Tests.git',"'"+(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests')+"'")
 
-if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or
      (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
     & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'),'--verbose')
@@ -42,7 +42,29 @@ try
         $script:DSCResourceName    = 'MSFT_xRDRemoteApp'
 
         $testInvalidCollectionName = 'InvalidCollectionNameLongerThan15'
-                
+        $testInvalidCollectionSplat = @{
+            CollectionName = $testInvalidCollectionName
+            DisplayName = 'name'
+            FilePath = 'path'
+            Alias = 'alias'
+        }
+
+        $xRDRemoteAppSplat = @{
+            CollectionName = 'TestCollection'
+            DisplayName = 'MyCalc (1.0.0)'
+            FilePath = 'c:\windows\system32\calc.exe'
+            Alias = 'Test-MyCalc-(1.0.0)'
+            Ensure = 'Present'
+            FileVirtualPath = 'c:\windows\system32\calc.exe'
+            FolderName = 'Test'
+            CommandLineSetting = 'DoNotAllow'
+            RequiredCommandLine = 'my-cmd'
+            IconIndex = 0
+            IconPath = 'c:\windows\system32\calc.exe'
+            UserGroups = 'DOMAIN\MyAppGroup_DLG'
+            ShowInWebAccess = $true
+        }
+
         Import-Module RemoteDesktop -Force
         
         #region Function Get-TargetResource
@@ -50,13 +72,91 @@ try
             Context "Parameter Values,Validations and Errors" {
 
                 It "Should error when CollectionName length is greater than 15" {
+                    { Get-TargetResource @testInvalidCollectionSplat } | Should Throw
+                }
+
+                $xRDRemoteAppSplat.CommandLineSetting = 'Invalid'
+                It 'Does only accept valid values for CommandLineSetting' {
+                    { Get-TargetResource @xRDRemoteAppSplat } | Should Throw
+                }
+
+                $xRDRemoteAppSplat.CommandLineSetting = 'DoNotAllow'
+            }
+
+            Context "Get output validation" {
+                
+                Mock -CommandName Get-RDRemoteApp
+                Mock -CommandName Get-RDSessionCollection
+
+                It 'Given the RemoteApp is not created yet, get returns Absent' {
+                    (Get-TargetResource @xRDRemoteAppSplat).Ensure | Should Be 'Absent'
+                }
+
+                Mock -CommandName Get-RDRemoteApp -MockWith {
+                    @{
+                        CollectionName = 'TestCollection'
+                        DisplayName = 'MyCalc (1.0.0)'
+                        FilePath = 'c:\windows\system32\calc.exe'
+                        Alias = 'Test-MyCalc-(1.0.0)'
+                        FileVirtualPath = 'c:\windows\system32\calc.exe'
+                        FolderName = 'Test'
+                        CommandLineSetting = 'DoNotAllow'
+                        RequiredCommandLine = 'my-cmd'
+                        IconIndex = 0
+                        IconPath = 'c:\windows\system32\calc.exe'
+                        UserGroups = 'DOMAIN\MyAppGroup_DLG'
+                        ShowInWebAccess = $true
+                    }
+                }
+
+                It 'Given the RemoteApp is created, get returns Present' {
+                    (Get-TargetResource @xRDRemoteAppSplat).Ensure | Should Be 'Present'
+                }
+
+                $excludeParameters = @(
+                    'Verbose'
+                    'Debug'
+                    'ErrorAction'
+                    'WarningAction'
+                    'InformationAction'
+                    'ErrorVariable'
+                    'WarningVariable'
+                    'InformationVariable'
+                    'OutVariable'
+                    'OutBuffer'
+                    'PipelineVariable'
+                )
+
+                $allParameters = (Get-Command Get-TargetResource).Parameters.Keys | Where-Object{$_ -notin $excludeParameters} | ForEach-Object {
+                    @{
+                        Property = $_
+                        Value = $xRDRemoteAppSplat[$_]
+                    }
+                }
+
+                $get = Get-TargetResource @xRDRemoteAppSplat
+                It 'Get returns property <Property> with value <Value>' {
+                    Param(
+                        $Property,
+                        $Value
+                    )
+
+                    $get.$Property | Should Be $Value
+                } -TestCases $allParameters
+
+                Mock -CommandName Get-RDSessionCollection -MockWith {
+                    Write-Error 'Collection not found!'
+                }
+
+                It 'Given that the CollectionName is not found in the SessionDeployment, an error is generated' {
+                    try
                     {
-                        Get-TargetResource `
-                        -CollectionName $testInvalidCollectionName `
-                        -DisplayName 'name' `
-                        -FilePath 'path' `
-                        -Alias 'alias' `
-                     } | Should Throw
+                        Get-TargetResource @xRDRemoteAppSplat -ErrorVariable collectionError
+                    }
+                    catch
+                    {
+                        $collectionError[-1].Exception.Message | Should Be 'Failed to lookup RD Session Collection TestCollection. Error: Collection not found!' 
+                    }
                 }
             }
         }
@@ -67,13 +167,57 @@ try
             Context "Parameter Values,Validations and Errors" {
 
                 It "Should error when CollectionName length is greater than 15" {
+                    { Set-TargetResource @testInvalidCollectionSplat } | Should Throw
+                }
+
+                $xRDRemoteAppSplat.CommandLineSetting = 'Invalid'
+                It 'Does only accept valid values for CommandLineSetting' {
+                    { Get-TargetResource @xRDRemoteAppSplat } | Should Throw
+                }
+
+                $xRDRemoteAppSplat.CommandLineSetting = 'DoNotAllow'
+            }
+
+            Context 'Validate Set Actions' {
+
+                Mock -CommandName Get-RDSessionCollection
+                Mock -CommandName Get-RDRemoteApp
+                Mock -CommandName New-RDRemoteApp
+                Mock -CommandName Remove-RDRemoteApp
+                Mock -CommandName Set-RDRemoteApp
+
+                It 'Given that the RemoteApp does not exist yet and Ensure is set to Present, New-RDRemoteApp is called' {
+                    Set-TargetResource @xRDRemoteAppSplat
+                    Assert-MockCalled -CommandName New-RDRemoteApp -Times 1 -Scope It
+                }
+
+                Mock -CommandName Get-RDRemoteApp -MockWith { $true }
+
+                It 'Given that the RemoteApp does exist and Ensure is set to Present, Set-RDRemoteApp is called' {
+                    Set-TargetResource @xRDRemoteAppSplat
+                    Assert-MockCalled -CommandName Set-RDRemoteApp -Times 1 -Scope It
+                }
+
+                $xRDRemoteAppSplat.Ensure = 'Absent'
+                It 'Given that the RemoteApp exists and Ensure is set to Absent, Remove-RDRemoteApp is called' {
+                    Set-TargetResource @xRDRemoteAppSplat
+                    Assert-MockCalled -CommandName Remove-RDRemoteApp -Times 1 -Scope It
+                }
+                $xRDRemoteAppSplat.Ensure = 'Present'
+
+                Mock -CommandName Get-RDSessionCollection -MockWith {
+                    Write-Error 'Collection not found!'
+                }
+
+                It 'Given that the CollectionName is not found in the SessionDeployment, an error is generated' {
+                    try
                     {
-                        Set-TargetResource `
-                        -CollectionName $testInvalidCollectionName `
-                        -DisplayName 'name' `
-                        -FilePath 'path' `
-                        -Alias 'alias' `
-                     } | Should Throw
+                        Set-TargetResource @xRDRemoteAppSplat -ErrorVariable collectionError
+                    }
+                    catch
+                    {
+                        $collectionError[-1].Exception.Message | Should Be 'Failed to lookup RD Session Collection TestCollection. Error: Collection not found!' 
+                    }
                 }
             }
         }
@@ -84,14 +228,87 @@ try
             Context "Parameter Values,Validations and Errors" {
 
                 It "Should error when CollectionName length is greater than 15" {
+                    { Test-TargetResource @testInvalidCollectionSplat } | Should Throw
+                }
+                
+                $xRDRemoteAppSplat.CommandLineSetting = 'Invalid'
+                It 'Does only accept valid values for CommandLineSetting' {
+                    { Get-TargetResource @xRDRemoteAppSplat } | Should Throw
+                }
+
+                $xRDRemoteAppSplat.CommandLineSetting = 'DoNotAllow'
+            }
+
+            Context 'Test output validation' {
+                Mock -CommandName Get-RDSessionCollection
+                Mock -CommandName Get-RDRemoteApp
+
+                It 'Given that the RemoteApp does not exist yet and Ensure is set to Present, test returns false' {
+                    Test-TargetResource @xRDRemoteAppSplat | Should Be $false
+                }
+
+                Mock -CommandName Get-RDRemoteApp -MockWith { 
+                    @{
+                        CollectionName = 'TestCollection'
+                        DisplayName = 'MyCalc (1.0.0)'
+                        FilePath = 'c:\windows\system32\calc.exe'
+                        Alias = 'Test-MyCalc-(1.0.0)'
+                        FileVirtualPath = 'c:\windows\system32\calc.exe'
+                        FolderName = 'Test'
+                        CommandLineSetting = 'DoNotAllow'
+                        RequiredCommandLine = 'my-cmd'
+                        IconIndex = 0
+                        IconPath = 'c:\windows\system32\calc.exe'
+                        UserGroups = 'DOMAIN\MyAppGroup_DLG'
+                        ShowInWebAccess = $true
+                    }
+                }
+
+                It 'Given that the RemoteApp does exist and Ensure is set to Present, test returns true' {
+                    Test-TargetResource @xRDRemoteAppSplat | Should Be $true
+                }
+
+                $xRDRemoteAppSplat.Ensure = 'Absent'
+                It 'Given that the RemoteApp exists and Ensure is set to Absent, test returns false' {
+                    Test-TargetResource @xRDRemoteAppSplat | Should Be $false
+                }
+                $xRDRemoteAppSplat.Ensure = 'Present'
+
+                Mock -CommandName Get-RDRemoteApp -MockWith { 
+                    @{
+                        CollectionName = 'TestCollection'
+                        DisplayName = 'MyCalc (1.0.0)'
+                        FilePath = 'c:\windows\system32\calc.exe'
+                        Alias = 'Test-MyCalc-(1.0.0)'
+                        FileVirtualPath = 'c:\windows\system32\calc.exe'
+                        FolderName = 'Test'
+                        CommandLineSetting = 'Allow'
+                        RequiredCommandLine = 'my-cmd'
+                        IconIndex = 0
+                        IconPath = 'c:\windows\system32\calc.exe'
+                        UserGroups = 'DOMAIN\MyAppGroup_DLG'
+                        ShowInWebAccess = $true
+                    }
+                }
+
+                It 'Given that the RemoteApp exists and Ensure is set to Present and a single setting is misconfigured, test returns false' {
+                    Test-TargetResource @xRDRemoteAppSplat | Should Be $false
+                }
+
+                Mock -CommandName Get-RDSessionCollection -MockWith {
+                    Write-Error 'Collection not found!'
+                }
+
+                It 'Given that the CollectionName is not found in the SessionDeployment, an error is generated' {
+                    try
                     {
-                        Test-TargetResource `
-                        -CollectionName $testInvalidCollectionName `
-                        -DisplayName 'name' `
-                        -FilePath 'path' `
-                        -Alias 'alias' `
-                    } | Should Throw
-                }            
+                        Test-TargetResource @xRDRemoteAppSplat -ErrorVariable collectionError
+                    }
+                    catch
+                    {
+                        $collectionError[-1].Exception.Message | Should Be 'Failed to lookup RD Session Collection TestCollection. Error: Collection not found!' 
+                    }
+                }
             }
         }
         #endregion

--- a/tests/unit/MSFT_xRDSessionDeployment.tests.ps1
+++ b/tests/unit/MSFT_xRDSessionDeployment.tests.ps1
@@ -1,0 +1,212 @@
+$script:DSCModuleName      = '.\xRemoteDesktopSessionHost'
+$script:DSCResourceName    = 'MSFT_xRDSessionDeployment'
+
+#region HEADER
+
+# Unit Test Template Version: 1.2.1
+$script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+Write-Output @('clone','https://github.com/PowerShell/DscResource.Tests.git',"'"+(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests')+"'")
+
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or
+     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+{
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'),'--verbose')
+}
+
+Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'DSCResource.Tests' -ChildPath 'TestHelper.psm1')) -Force
+
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
+    -TestType Unit
+
+#endregion HEADER
+
+function Invoke-TestSetup {
+
+}
+
+function Invoke-TestCleanup {
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment
+
+}
+
+# Begin Testing
+
+try
+{
+
+    Invoke-TestSetup
+
+    InModuleScope $script:DSCResourceName {
+        $script:DSCResourceName    = 'MSFT_xRDSessionDeployment'
+
+        Import-Module RemoteDesktop -Force
+
+        $sessionDeploymentSplat = @{
+            SessionHost      = 'sessionhost.lan'
+            ConnectionBroker = 'connectionbroker.lan'
+            WebAccessServer  = 'webaccess.lan'
+        }
+        
+        #region Function Get-TargetResource
+        Describe "$($script:DSCResourceName)\Get-TargetResource" {
+
+            Mock -CommandName Get-RDServer -MockWith {
+                [pscustomobject]@{
+                    Server = 'sessionhost.lan'
+                    Roles = @(
+                        'RDS-RD-SERVER'
+                    )
+                }
+                [pscustomobject]@{
+                    Server = 'connectionbroker.lan'
+                    Roles = @(
+                        'RDS-CONNECTION-BROKER'
+                    )
+                }
+                [pscustomobject]@{
+                    Server = 'webaccess.lan'
+                    Roles = @(
+                        'RDS-WEB-ACCESS'
+                    )
+                }
+            }
+
+            Mock -CommandName Start-Service -MockWith {
+                Throw "Throwing from Start-Service mock"
+            }
+            
+            Mock -CommandName Get-Service -MockWith {
+                [pscustomobject]@{
+                    Status = 'Stopped'
+                }
+            }
+
+            It 'Given the RDMS service is stopped, Get attempts to start the service' {
+                Get-TargetResource @sessionDeploymentSplat -WarningAction SilentlyContinue
+                Assert-MockCalled -CommandName Start-Service -Times 1 -Scope It
+            }
+
+            It 'Given RDMS service is stopped and start fails a warning is displayed' {
+                Get-TargetResource @sessionDeploymentSplat -WarningVariable serviceWarning -WarningAction SilentlyContinue
+                $serviceWarning | Should Be 'Failed to start RDMS service. Error: Throwing from Start-Service mock'
+            }
+
+            Mock -CommandName Get-Service -MockWith {
+                [pscustomobject]@{
+                    Status = 'Running'
+                }
+            }
+
+            It 'Given the RDMS service is running, Get does not attempt to start the service' {
+                Get-TargetResource @sessionDeploymentSplat
+                Assert-MockCalled -CommandName Start-Service -Times 0 -Scope It
+            }
+
+            $get = Get-TargetResource @sessionDeploymentSplat
+            It 'Get returns property <property>' {
+                Param(
+                    $Property
+                )
+
+                $get.$Property | Should Not BeNullOrEmpty
+            } -TestCases @(
+                @{
+                    Property = 'SessionHost'
+                }
+                @{
+                    Property = 'ConnectionBroker'
+                }
+                @{
+                    Property = 'WebAccessServer'
+                }
+            )
+
+        }
+        #endregion
+
+        #region Function Set-TargetResource
+        Describe "$($script:DSCResourceName)\Set-TargetResource" {
+            
+            Mock -CommandName New-RDSessionDeployment
+
+            Set-TargetResource @sessionDeploymentSplat
+            It 'Set calls New-RDSessionDeployment with all required parameters' {
+                Assert-MockCalled -CommandName New-RDSessionDeployment -Times 1 -ParameterFilter {
+                    $SessionHost -eq 'sessionhost.lan' -and
+                    $ConnectionBroker -eq 'connectionbroker.lan' -and 
+                    $WebAccessServer -eq 'webaccess.lan'
+                }
+            }
+
+        }
+        #endregion
+
+        #region Function Test-TargetResource
+        Describe "$($script:DSCResourceName)\Test-TargetResource" {
+            
+            Mock -CommandName Get-Service -MockWith {
+                [pscustomobject]@{
+                    Status = 'Running'
+                }
+            }
+            Mock -CommandName Get-RDServer -MockWith {
+                [pscustomobject]@{
+                    Server = 'sessionhost.lan'
+                    Roles = @(
+                        'RDS-RD-SERVER'
+                    )
+                }
+                [pscustomobject]@{
+                    Server = 'connectionbrokernew.lan'
+                    Roles = @(
+                        'RDS-CONNECTION-BROKER'
+                    )
+                }
+                [pscustomobject]@{
+                    Server = 'webaccess.lan'
+                    Roles = @(
+                        'RDS-WEB-ACCESS'
+                    )
+                }
+            }
+
+            It 'Given the ConnectionBroker is not targetted in this deployment, test returns false' {
+                Test-TargetResource @sessionDeploymentSplat | Should Be $false
+            }
+
+            Mock -CommandName Get-RDServer -MockWith {
+                [pscustomobject]@{
+                    Server = 'sessionhost.lan'
+                    Roles = @(
+                        'RDS-RD-SERVER'
+                    )
+                }
+                [pscustomobject]@{
+                    Server = 'connectionbroker.lan'
+                    Roles = @(
+                        'RDS-CONNECTION-BROKER'
+                    )
+                }
+                [pscustomobject]@{
+                    Server = 'webaccess.lan'
+                    Roles = @(
+                        'RDS-WEB-ACCESS'
+                    )
+                }
+            }
+
+            It 'Given the SessionDeployment is completed, test returns true' {
+                Test-TargetResource @sessionDeploymentSplat | Should Be $true
+            }
+        }
+        #endregion
+    }
+}
+finally
+{
+    #region FOOTER
+    Invoke-TestCleanup
+    #endregion
+}


### PR DESCRIPTION
<!--
Thanks for submitting a Pull Request (PR) to this project. Your contribution to this project is greatly appreciated!

Please prefix the PR title with the resource name, i.e. 'xComputer: My short description'
If this is a breaking change, then also prefix the PR title with 'BREAKING CHANGE:', i.e. 'BREAKING CHANGE: xComputer: My short description'

To aid community reviewers in reviewing and merging your PR, please take the time to run through the below checklist.
Change to [x] for each task in the task list that applies to this PR.
-->
**Pull Request (PR) description**
This PR adds bugfixes and tests for the xRDSessionDeployment and xRDRemoteApp resources. It also adds the capability to xRDRemoteApp to uninstall RemoteApps after they have been deployed, this PR enables describing these as Absent. 

**This Pull Request (PR) fixes the following issues:**
xRDSessionDeployment Results in "You cannot call a method on a null-valued expression." Fixes #39 
xRemoteApp: Ignores the CollectionName set by the user. Fixes #41

**Task list:**
- [X] Change details added to Unreleased section of README.md?
- [X] Added/updated descriptions in .schema.mof files where appropriate?
- [X] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [X] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xremotedesktopsessionhost/42)
<!-- Reviewable:end -->
